### PR TITLE
I propose that any query longer than 2048 chars get truncated on the queries page

### DIFF
--- a/djangosampler/templates/djangosampler/queries.html
+++ b/djangosampler/templates/djangosampler/queries.html
@@ -35,7 +35,7 @@
             <td>{{ query.count }}</td>
             <td>{{ query.total_duration|floatformat:4 }}</td>
             <td>{{ query.total_cost }}</td>
-            <td>{{ query.query }}</td>
+            <td>{{ query.query|truncatechars:2048 }}</td>
         </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
Really cool: Seeing all my queries with your awesome plugin!
Not so cool: Taking 5 whole minutes to scroll down 312.7ft of a mega-monstrosity-query just to see that it actually executed pretty quickly.

Anything longer than 2048 was probably not meant to be shown in it's entirety on your list page.
